### PR TITLE
Fix for dispose function in HLS.as

### DIFF
--- a/src/org/mangui/hls/HLS.as
+++ b/src/org/mangui/hls/HLS.as
@@ -77,8 +77,8 @@ package org.mangui.hls {
             _altAudioLevelLoader.dispose();
             _audioTrackController.dispose();
             _levelController.dispose();
+             _hlsNetStream.dispose_();
             _streamBuffer.dispose();
-            _hlsNetStream.dispose_();
             _levelLoader = null;
             _altAudioLevelLoader = null;
             _audioTrackController = null;


### PR DESCRIPTION
while disposing HLS stream it throws a NPE,
TypeError: Error #1009: Cannot access a property or method of a null object reference.
    at org.mangui.hls.stream::StreamBuffer/stop()[flashls/src/org/mangui/hls/stream/StreamBuffer.as:87]
    at org.mangui.hls.stream::HLSNetStream/close()[flashls/src/org/mangui/hls/stream/HLSNetStream.as:346]
    at org.mangui.hls.stream::HLSNetStream/dispose_()[flashls/src/org/mangui/hls/stream/HLSNetStream.as:353]
    at org.mangui.hls::HLS/dispose()[flashls/src/org/mangui/hls/HLS.as:81]

Fixed it by disposing _hlsNetStream first and then disposing _streamBuffer
